### PR TITLE
Override key events

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,14 +95,13 @@ The following instructions for interacting with the viewer will display when the
 * Press `t` to toggle the trajectories on or off
 * Press `m` to toggle the step markers on or off
 * Press `b` to toggle the background on or off
-* Press `w` to switch to a wireframe rendering mode
-* Press `s` to switch to a solid rendering mode
-* Press `v` to reset to the default viewpoint
+* Press `w` to toggle between wireframe and solid modes
+* Press `v` to switch to an isometric view
 * Press `d` to set the display window size
 * Press `i` to set the camera viewpoint
 * Press `p` to print the current display settings
 * Press `h` to export the viewer to an HTML file
-* Press `q` or `e` to quit the viewer
+* Press `q` to quit the viewer
 
 While the primary interface is with the viewer window, some commands require text entry in the terminal window. Any saving commands will require the user to enter a file path in the terminal. Some of these functions have been specifically designed to provide more precise control of the viewer than can be achieved using the mouse alone.
 

--- a/src/geviewer/geviewer.py
+++ b/src/geviewer/geviewer.py
@@ -8,7 +8,7 @@ import shutil
 import zipfile
 import tempfile
 from matplotlib.colors import LinearSegmentedColormap
-from geviewer import utils, parser
+from geviewer import utils, parser, plotter
 
 
 class GeViewer:
@@ -102,21 +102,22 @@ class GeViewer:
         '''
         Create a PyVista plotter.
         '''
-        self.plotter = pv.Plotter(title='GeViewer — ' + str(Path(self.filenames[0]).resolve()) + \
-                                  ['',' + {} more'.format(len(self.filenames)-1)]\
-                                  [(len(self.filenames)>1) and not self.safe_mode],\
-                                  off_screen=self.off_screen)
+        self.plotter = plotter.Plotter(title='GeViewer — ' + str(Path(self.filenames[0]).resolve()) \
+                                       + ['',' + {} more'.format(len(self.filenames)-1)]\
+                                         [(len(self.filenames)>1) and not self.safe_mode],\
+                                       off_screen=self.off_screen)
         self.plotter.add_key_event('c', self.save_screenshot)
         self.plotter.add_key_event('t', self.toggle_tracks)
         self.plotter.add_key_event('m', self.toggle_step_markers)
         self.plotter.add_key_event('b', self.toggle_background)
-        # solid and wireframe rendering modes have key events by default
+        self.plotter.add_key_event('w', self.toggle_wireframe)
         self.plotter.add_key_event('d', self.set_window_size)
         self.plotter.add_key_event('i', self.set_camera_view)
         self.plotter.add_key_event('p', self.print_view_params)
         self.plotter.add_key_event('h', self.export_to_html)
         self.plotter.set_background('lightskyblue',top='midnightblue')
         self.bkg_on = True
+        self.wireframe = False
         
         # compute the initial camera position
         fov = self.view_params[0]
@@ -302,6 +303,20 @@ class GeViewer:
             self.plotter.set_background('lightskyblue',top='midnightblue')
         else:
             self.plotter.set_background('white')
+        if not self.off_screen:
+            self.plotter.update()
+
+
+    def toggle_wireframe(self):
+        '''
+        Toggle between solid and wireframe display modes.
+        '''
+        self.wireframe = not self.wireframe
+        print('Switching to ' + ['solid','wireframe'][self.wireframe] + ' mode.')
+        if self.wireframe:
+            self.actors[2].prop.SetRepresentationToWireframe()
+        else:
+            self.actors[2].prop.SetRepresentationToSurface()
         if not self.off_screen:
             self.plotter.update()
 

--- a/src/geviewer/main.py
+++ b/src/geviewer/main.py
@@ -26,14 +26,13 @@ def print_instructions():
     print('* Press "t" to toggle the trajectories on or off')
     print('* Press "m" to toggle the step markers on or off')
     print('* Press "b" to toggle the background on or off')
-    print('* Press "w" to switch to a wireframe rendering mode')
-    print('* Press "s" to switch to a solid rendering mode')
-    print('* Press "v" to reset to the default viewpoint')
+    print('* Press "w" to toggle between wireframe and solid modes')
+    print('* Press "v" to switch to an isometric view')
     print('* Press "d" to set the display window size')
     print('* Press "i" to set the camera viewpoint')
     print('* Press "p" to print the current display settings')
     print('* Press "h" to export the viewer to an HTML file')
-    print('* Press "q" or "e" to quit the viewer')
+    print('* Press "q" to quit the viewer')
     print()
 
 

--- a/src/geviewer/plotter.py
+++ b/src/geviewer/plotter.py
@@ -1,0 +1,33 @@
+import pyvista as pv
+
+
+class Plotter(pv.Plotter):
+    '''
+    Custom plotter class that overrides the default key events for the viewer.
+    '''
+
+    def geviewer_key_event(self, obj, event):
+        '''
+        This function is called when a key is pressed in the viewer.
+        It overrides the default key events for the viewer, allowing
+        only the custom key events defined in the GeViewer class.
+        '''
+        key = obj.GetInteractor().GetKeyCode()
+        overriden_keys = ['c', 't', 'm', 'b', 'd', 'i', 'p', 'h',\
+                          'w', 'e','+', '-', 's', 'r', 'u', 'f']
+        if key in overriden_keys:
+            return
+        else:
+            # commands for other keys are passed to the original key event handler
+            obj.OnChar()
+
+
+    def show(self, *args, **kwargs):
+        '''
+        Override the default key events and then show the plotter window.
+        '''
+        interactor_style = self.iren.interactor.GetInteractorStyle()
+        interactor_style.AddObserver("CharEvent", self.geviewer_key_event)
+
+        # now call the original show method
+        super().show(*args, **kwargs)

--- a/src/geviewer/utils.py
+++ b/src/geviewer/utils.py
@@ -95,7 +95,7 @@ async def prompt_for_screenshot_path():
                 return None
             if not file_path.endswith(('.png', '.svg', '.eps', '.ps', '.pdf', '.tex')):
                 raise ValueError
-            if not os.path.isdir('/'.join(file_path.split('/')[:-1])):
+            if not os.path.isdir('/'.join(str(Path(file_path).resolve()).split('/')[:-1])):
                 raise ValueError
             break
         except ValueError:
@@ -137,7 +137,7 @@ def prompt_for_file_path():
                 return None
             if not file_path.endswith('.gev'):
                 raise ValueError
-            if not os.path.isdir('/'.join(file_path.split('/')[:-1])):
+            if not os.path.isdir('/'.join(str(Path(file_path).resolve()).split('/')[:-1])):
                 raise ValueError
             print()
             break
@@ -185,7 +185,7 @@ async def prompt_for_html_path():
                 return None
             if not file_path.endswith('.html'):
                 raise ValueError
-            if not os.path.isdir('/'.join(file_path.split('/')[:-1])):
+            if not os.path.isdir('/'.join(str(Path(file_path).resolve()).split('/')[:-1])):
                 raise ValueError
             break
         except ValueError:


### PR DESCRIPTION
Use a new child class of `pyvista.Plotter` to override the default actions on key events. This fixes an issue where certain keys had conflicting actions and frees up more keys for use as GeViewer commands.